### PR TITLE
Improvement: store table id to reduce JOINs in queries

### DIFF
--- a/redshift_console/queries.yaml
+++ b/redshift_console/queries.yaml
@@ -103,6 +103,10 @@ table_design_status:
 
   SELECT * FROM temp_tables_report ORDER BY size_in_mb DESC;
 tables_rows_sort_status:
+# The query is limited to the current database in use,
+# since STV_TBL_PERM holds info on tables from all databases
+# in contrary to pg_class and pg_namespace which are limited
+# to the database of the current connection.
   SELECT id as table_id, SUM(rows) as total_rows, SUM(sorted_rows) as sorted_rows, SUM(sorted_rows)::float/SUM(rows)::float as percent_sorted
   FROM stv_tbl_perm WHERE db_id=%s AND temp=0
   GROUP BY id

--- a/redshift_console/queries.yaml
+++ b/redshift_console/queries.yaml
@@ -24,13 +24,10 @@ query_alerts:
   AND query IN %s
   ORDER BY event_time ASC;
 table_load_errors:
-  SELECT stv_tbl_perm.name as table, colname as column, err_reason as error, starttime as time, COUNT(*) as errors_count
+  SELECT tbl as table_id, colname as column, err_reason as error, starttime as time, COUNT(*) as errors_count
   FROM stl_load_errors
-  INNER JOIN (SELECT DISTINCT id,name FROM stv_tbl_perm) as stv_tbl_perm
-  ON stl_load_errors.tbl=stv_tbl_perm.id
   WHERE starttime BETWEEN GETDATE()- INTERVAL '24 hours' AND GETDATE()
-  GROUP BY starttime, err_reason,stv_tbl_perm.name, colname
-  ORDER BY stv_tbl_perm.name, starttime;
+  GROUP BY tbl, starttime, err_reason, colname;
 table_design_status:
   DROP TABLE IF EXISTS temp_staging_tables_1;
   DROP TABLE IF EXISTS temp_staging_tables_2;
@@ -106,9 +103,11 @@ table_design_status:
 
   SELECT * FROM temp_tables_report ORDER BY size_in_mb DESC;
 tables_rows_sort_status:
-  SELECT TRIM(pg_namespace.nspname) as schema, TRIM(pg_class.relname) as table_name, SUM(stv_tbl_perm.rows) as total_rows, SUM(stv_tbl_perm.sorted_rows) as sorted_rows, SUM(stv_tbl_perm.sorted_rows)::float/SUM(stv_tbl_perm.rows)::float as percent_sorted
+  SELECT id as table_id, SUM(rows) as total_rows, SUM(sorted_rows) as sorted_rows, SUM(sorted_rows)::float/SUM(rows)::float as percent_sorted
   FROM stv_tbl_perm
-  INNER JOIN pg_class  ON pg_class.relname=stv_tbl_perm.name
-  INNER JOIN pg_namespace ON pg_namespace.oid=pg_class.relnamespace
-  GROUP BY pg_namespace.nspname, pg_class.relname
+  GROUP BY id
   HAVING SUM(stv_tbl_perm.rows)>0;
+table_id_mapping:
+  SELECT pg_class.OID as table_id, pg_class.relname as table_name, pg_namespace.nspname as schema_name 
+  FROM pg_class INNER JOIN pg_namespace 
+  ON pg_class.relnamespace=pg_namespace.OID;

--- a/redshift_console/queries.yaml
+++ b/redshift_console/queries.yaml
@@ -104,10 +104,10 @@ table_design_status:
   SELECT * FROM temp_tables_report ORDER BY size_in_mb DESC;
 tables_rows_sort_status:
   SELECT id as table_id, SUM(rows) as total_rows, SUM(sorted_rows) as sorted_rows, SUM(sorted_rows)::float/SUM(rows)::float as percent_sorted
-  FROM stv_tbl_perm
+  FROM stv_tbl_perm WHERE db_id=%s AND temp=0
   GROUP BY id
   HAVING SUM(stv_tbl_perm.rows)>0;
 table_id_mapping:
-  SELECT pg_class.OID as table_id, pg_class.relname as table_name, pg_namespace.nspname as schema_name 
+  SELECT pg_class.OID as table_id, TRIM(pg_class.relname) as table_name, TRIM(pg_namespace.nspname) as schema_name
   FROM pg_class INNER JOIN pg_namespace 
   ON pg_class.relnamespace=pg_namespace.OID;

--- a/redshift_console/redshift.py
+++ b/redshift_console/redshift.py
@@ -6,6 +6,7 @@ import yaml
 import os
 import toro
 import settings
+import re
 from tornado.ioloop import IOLoop, PeriodicCallback
 from tornado.gen import coroutine, Return
 from tornado.concurrent import run_on_executor
@@ -225,9 +226,18 @@ class Tables(DataFetcher):
         self.load_errors = {}
         self.tables_rows_sort_status = {}
         self.table_id_mapping = {}
+        self._db_id = None
 
     def get(self, namespace, table):
         return self.schemas.get(namespace, {}).get(table, None)
+
+    @coroutine
+    def _fetch_current_db_id(self):
+        with self._get_connection() as connection:
+            dbname = re.search("dbname='(\w+)'", connection.dsn).group(1)
+            with connection.cursor() as cursor:
+                cursor.execute('SELECT OID FROM pg_database WHERE datname=%s', (dbname, ))
+                self._db_id = cursor.fetchone()[0]
 
     def get_schemas(self):
         schemas = {}
@@ -247,7 +257,8 @@ class Tables(DataFetcher):
 
     @coroutine
     def refresh(self):
-        yield self._fetch_table_id_mapping()
+        if not self._db_id:
+            yield self._fetch_current_db_id()
         yield self._fetch_schema()
         yield self._fetch_tables_rows_sort_status()
         yield self._fetch_design_status()
@@ -255,14 +266,16 @@ class Tables(DataFetcher):
 
     @coroutine
     def _fetch_schema(self):
-        results = yield self.execute_query("select nspname as name from pg_namespace where nspowner <> 1;")
-        namespaces = map(lambda r: "'%s'" % r['name'], results)
+        results = yield self.execute_query(sql_queries['table_id_mapping'])
+        namespaces = list(set(map(lambda r: "'%s'" % r['schema_name'], results)))
+        tables_ids = {row.pop('table_id'): row for row in results}
+        self.table_id_mapping = tables_ids
         namespaces.insert(0, "'$user'")
         namespaces.insert(1, "'public'")
 
         search_path_query = 'set search_path to {};'.format(', '.join(namespaces))
 
-        columns = yield self.execute_query(search_path_query + "SELECT * FROM pg_table_def WHERE schemaname <> 'pg_catalog';", namespaces)
+        columns = yield self.execute_query(search_path_query + "SELECT * FROM pg_table_def WHERE schemaname NOT IN ('pg_catalog', 'pg_toast', 'information_schema');", namespaces)
         schema = {}
         for col in columns:
             namespace = schema.setdefault(col['schemaname'], {})
@@ -291,7 +304,8 @@ class Tables(DataFetcher):
     @coroutine
     def _fetch_tables_rows_sort_status(self):
         query = sql_queries['tables_rows_sort_status']
-        res = yield self.execute_query(query)
+        res = yield self.execute_query(query, (self._db_id,))
+
         for row in res:
             schema, table_name = self.table_id_mapping[row['table_id']]['schema_name'], \
                                  self.table_id_mapping[row['table_id']]['table_name']
@@ -314,15 +328,6 @@ class Tables(DataFetcher):
                 for key in ('has_col_encoding', 'pct_slices_populated', 'size_in_mb', 'pct_skew_across_slices', 'has_sort_key', 'has_dist_key'):
                     table['metadata'][key] = row[key]
 
-    @coroutine
-    def _fetch_table_id_mapping(self):
-        """
-        Stores a dictionary with table name and schema name
-        per table id.
-        """
-        result = yield self.execute_query(sql_queries['table_id_mapping'])
-        mapping = {row.pop('table_id'): row for row in result}
-        self.table_id_mapping = mapping
 
 
 

--- a/redshift_console/redshift.py
+++ b/redshift_console/redshift.py
@@ -227,12 +227,20 @@ class Tables(DataFetcher):
         self.tables_rows_sort_status = {}
         self.table_id_mapping = {}
         self._db_id = None
+        self.load_errors_updated_at = None
 
     def get(self, namespace, table):
         return self.schemas.get(namespace, {}).get(table, None)
 
     @coroutine
     def _fetch_current_db_id(self):
+        """
+        db_id is used to limit the querying of STV_TBL_PERM.
+        pg_class and pg_namespace are limited to the scope of
+        the current connection (and therefore to a single database)
+        while STV_TBL_PERM contains info on tables from all databases
+        in the cluster.
+        """
         with self._get_connection() as connection:
             dbname = re.search("dbname='(\w+)'", connection.dsn).group(1)
             with connection.cursor() as cursor:


### PR DESCRIPTION
Added table_id_mapping for storing table name and schema name per table id.

Since we use the same join on pg_class and pg_namespace for resolving schema name and table name from table id, we've decided to create this mapping once (refreshed with Tables), and enrich the query results.
